### PR TITLE
商品情報編集

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :move_to_index, only: [:edit]
   before_action :set_item, only: [:edit, :show, :update]
+  before_action :move_to_index, only: [:edit]
+  
   
   def index
     @items = Item.order('created_at DESC')
@@ -47,7 +48,6 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    @item = Item.find(params[:id])
   unless @item.user.id == current_user.id
     redirect_to root_path
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-
+  before_action :move_to_index, only: [:edit]
+  before_action :set_item, only: [:edit, :show, :update]
+  
   def index
     @items = Item.order('created_at DESC')
   end
@@ -19,15 +21,15 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
+    
   end
   
   def edit
-    @item = Item.find(params[:id])
+    
   end
 
   def update
-    @item = Item.find(params[:id])
+    
     if @item.update(item_params)
       redirect_to item_path(@item)
     else
@@ -39,5 +41,16 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:image, :title, :description, :status_id, :delivery_charge_id, :prefecture_id, :delivery_date_id, :category_id, :price).merge(user_id: current_user.id)
   end
- 
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
+  def move_to_index
+    @item = Item.find(params[:id])
+  unless @item.user.id == current_user.id
+    redirect_to root_path
+  end
+end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,16 @@ class ItemsController < ApplicationController
   end
   
   def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path(@item)
+    else
+      render :edit
+    end
   end
 
  private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,7 +4,7 @@ class Item < ApplicationRecord
   # テーブル とのアソシエーション
   belongs_to :user
  
-  has_one :purchase
+  # has_one :purchase
  
 
   # アクティブハッシュとのアソシエーション

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,7 +4,7 @@ class Item < ApplicationRecord
   # テーブル とのアソシエーション
   belongs_to :user
  
-  # has_one :purchase
+  has_one :purchase
  
 
   # アクティブハッシュとのアソシエーション

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,9 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%# <%= form_with(model: @item, local: true) do |f| %> %>
+    <%= form_with(model: @item, local: true) do |f| %>
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# <%render 'shared/error_messages', model: f.object %> %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 商品画像 %>
@@ -22,7 +22,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%# <%= f.file_field :item_image, id:"item-image" %> %>
+        <%= f.file_field :item_image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -32,13 +32,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%# <%= f.text_area :title, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %> %>
+      <%= f.text_area :title, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.text_area :item_info, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %> %>
+        <%= f.text_area :item_info, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -51,12 +51,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %> %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %> %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -72,17 +72,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:delivery_charge_id, DeliveryCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %> %>
+        <%= f.collection_select(:delivery_charge_id, DeliveryCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %> %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:delivery_date_id, Deliverydate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %> %>
+        <%= f.collection_select(:delivery_date_id, DeliveryDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -100,7 +100,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%# <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %> %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -140,7 +140,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる',"#" , class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -8,10 +8,8 @@ app/assets/stylesheets/items/new.css %>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with(model: @item, local: true) do |f| %>
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
+        <%= render 'shared/error_messages', model: f.object %>
+   
     <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
@@ -140,7 +138,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる',"#" , class:"back-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,11 +133,11 @@
         <%= link_to item_path(item) do %>
         <div class='item-img-content'>
         <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
-          <%# <% if item.purchase.present? %> %>
+          <%# <% if item.purchase.present? %> 
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# <% end %> %>
+          <%# <% end %> 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -6,10 +6,8 @@
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
 
-    <%= form_with model: @item, local: true do |f| %>
-
+   <%= form_with(model: @item, local: true) do |f| %>
     <%= render 'shared/error_messages', model: f.object %>
- 
     <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image.variant(resize: '500') ,class:"item-box-img" %>
-       <%# <% if @item.purchase.present? %> %>
+       <%# <% if @item.purchase.present? %> 
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-       <%# <% end %> %>
+       <%# <% end %> 
           </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -24,15 +24,16 @@
     </div>
    <% if user_signed_in? %>
    
-    <% if current_user.id == @item.user_id %>
-<%# if current_user.id == @item.user_id && @item.purchase.nil? %>         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+
+<% if current_user.id == @item.user_id && @item.purchase.nil? %>
+         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
            <p class="or-text">or</p> 
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %> 
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% else  %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-   <%# items_path(@item.id) %>
+    <%= link_to "購入画面に進む", items_path(@item.id)  ,class:"item-red-btn"%>
+   
     <% end %>
  <% end %>
     

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,8 +31,8 @@
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% else  %>
-    <%= link_to "購入画面に進む", items_path(@item.id)  ,class:"item-red-btn"%>
-   
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+   <%# items_path(@item.id) %>   
     <% end %>
  <% end %>
     

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,9 +23,8 @@
       </span>
     </div>
    <% if user_signed_in? %>
-   
-
-<% if current_user.id == @item.user_id && @item.purchase.nil? %>
+   <% if current_user.id == @item.user_id %>
+    <%# && @item.purchase.nil? %>
          <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
            <p class="or-text">or</p> 
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:new, :create, :show ]
+  resources :items, only: [:new, :create, :show, :edit, :update]
   
 end


### PR DESCRIPTION
what 商品情報編集の実装
why 商品情報を編集するため

Gyazo
ログイン中の出品者は商品情報編集ページに遷移できる
https://gyazo.com/b042ed41168bd1978124e9bedce902a5

必要な情報を入力して更新するを押すと商品情報が変更されている
https://gyazo.com/6fb25e4160c5c798910721ca37df4b16

入力に問題がある状態だと編集ページに戻りエラーメッセージが出て情報が保存されない
https://gyazo.com/6c72809a1f3cdd10d89e1600a719e262

何も編集せずに更新しても画像なしにならない
カテゴリーなど既に登録されている情報は編集ページを開いた時点で表示される
(2つとも確認できます)
https://gyazo.com/30976d7cd81e9e13df7d941b84aa7828

自信が出品していない商品の編集ページにurlを入力して遷移しようとするとトップページに遷移する
https://gyazo.com/3cd4ee38cfffa0f8ff8556d5896b6e13

ログアウト状態の場合、urlを直接入力して遷移しようとするとログインページに遷移する
https://gyazo.com/e07a5c7b8530323ca8d3fb6eb4f4bcc6
